### PR TITLE
feat: add configuration options (timeout, remote commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Role Variables
 * ```zabbix_agent_log_size``` (0) - size in MB to rotate log.  0 = use logrotate
 * ```zabbix_agent_server_ip``` (127.0.0.1) - ip address of zabbix server
 * ```zabbix_agent_server_active_ip``` (127.0.0.1) - ip of zabbix server providing active checks
+* ```zabbix_agent_timeout``` (3) - amount of time to spend on processing
+* ```zabbix_agent_allow_remote_commands``` (false) - allow zabbix-server to invoke commands on this agent when set to `true`.
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,3 +12,5 @@ zabbix_agent_psk_hash: kmWCW6jtSSFK7XRuMJct2fVINNL1QTYt
 zabbix_agent_log_size: 0
 zabbix_agent_server_ip: 127.0.0.1
 zabbix_agent_server_active_ip: 127.0.0.1
+zabbix_agent_timeout: 3
+zabbix_agent_allow_remote_commands: false

--- a/templates/zabbix_agent2.conf.j2
+++ b/templates/zabbix_agent2.conf.j2
@@ -7,7 +7,8 @@ Hostname={{ inventory_hostname }}
 HostMetadataItem=system.uname
 Include={{ zabbix_agent_include_path }}
 ControlSocket={{ zabbix_agent_control_socket_path }}
-DenyKey=system.run[*]
+Timeout={{ zabbix_agent_timeout }}
+{{'Allow' if zabbix_agent_allow_remote_commands else 'Deny'}}Key=system.run[*]
 
 TLSConnect=psk
 TLSAccept=psk


### PR DESCRIPTION
This PR adds two optional configuration options:

- `zabbix_agent_timeout ` to be able to override the default timeout of 3. Defaults to `3`
- `zabbix_agent_allow_remote_commands` to be able to allow the Zabbix Server to run commands on this agent. Defaults to `false`